### PR TITLE
Fix vercel.json schema and verify build config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,6 @@
   "outputDirectory": "frontend/.next",
   "framework": "nextjs",
   "installCommand": "cd frontend && npm install",
-  "rootDirectory": "frontend",
   "functions": {
     "frontend/app/**/*.tsx": {
       "runtime": "nodejs18.x"


### PR DESCRIPTION
Remove invalid `rootDirectory` from `vercel.json` and adjust commands to fix schema validation for monorepo deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-1be38cea-df2e-4666-9b89-38698b76a438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1be38cea-df2e-4666-9b89-38698b76a438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

