### PR TITLE
Fix vercel deployment for frontend nextjs app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,15 @@
 {
-  "framework": "nextjs"
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "frontend/$1"
+    }
+  ]
 }


### PR DESCRIPTION
Configure Vercel to build and serve the Next.js app from the `frontend` subdirectory to resolve deployment errors.

Vercel by default expects the Next.js application at the repository root. Since the actual Next.js app resides in the `/frontend` subdirectory, Vercel failed to locate the necessary build artifacts like `routes-manifest.json` after the build completed. This change explicitly tells Vercel where to find the Next.js project.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c95782e-e5e7-449a-9fd9-26646294515f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c95782e-e5e7-449a-9fd9-26646294515f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

